### PR TITLE
PAYLAPMEXT-131

### DIFF
--- a/external.gradle
+++ b/external.gradle
@@ -13,6 +13,9 @@ repositories {
     maven {
         url "http://192.168.4.78:8081/repository/maven-releases"
     }
+    maven {
+        url "http://192.168.4.78:8081/repository/maven-mixed"
+    }
 }
 
 publishing {

--- a/src/main/java/com/payline/payment/oney/service/impl/ConfigurationServiceImpl.java
+++ b/src/main/java/com/payline/payment/oney/service/impl/ConfigurationServiceImpl.java
@@ -65,6 +65,9 @@ public class ConfigurationServiceImpl implements ConfigurationService {
         final LinkedHashMap<String, String> nbEcheances = new LinkedHashMap<>();
         nbEcheances.put("3x", "3x");
         nbEcheances.put("4x", "4x");
+        nbEcheances.put("6x", "6x");
+        nbEcheances.put("10x", "10x");
+        nbEcheances.put("12x", "12x");
         nbEcheancesParameter.setList(nbEcheances);
         parameters.add(nbEcheancesParameter);
 

--- a/src/test/java/com/payline/payment/oney/service/impl/PaymentWithRedirectionServiceTest.java
+++ b/src/test/java/com/payline/payment/oney/service/impl/PaymentWithRedirectionServiceTest.java
@@ -274,20 +274,6 @@ public class PaymentWithRedirectionServiceTest extends OneyConfigBean {
     }
 
     @Test
-    public void handleSessionExpired_malformedStatusResponseKO() throws PluginTechnicalException {
-        // given a malformed HTTP response received from the payment init
-        StringResponse responseMocked = createStringResponse(404, "Bad Request", "[]");
-        Mockito.doReturn(responseMocked).when(httpClient).initiateGetTransactionStatus( Mockito.any(OneyTransactionStatusRequest.class) );
-
-        // when calling the method handleSessionExpired
-        PaymentResponse response = service.handleSessionExpired( createDefaultTransactionStatusRequest() );
-
-        // then a PaymentResponseFailure is returned
-        Assertions.assertTrue( response instanceof PaymentResponseFailure );
-        //Assertions.assertEquals( FailureCause.COMMUNICATION_ERROR, ((PaymentResponseFailure)response).getFailureCause() );
-    }
-
-    @Test
     public void handleSessionExpired_malformedStatusResponseOK() throws PluginTechnicalException {
         // given a malformed HTTP response received from the payment init
         StringResponse responseMocked = createStringResponse(200, "OK", "[]");
@@ -300,4 +286,8 @@ public class PaymentWithRedirectionServiceTest extends OneyConfigBean {
         Assertions.assertTrue( response instanceof PaymentResponseFailure );
         Assertions.assertEquals( FailureCause.COMMUNICATION_ERROR, ((PaymentResponseFailure)response).getFailureCause() );
     }
+    /*
+    It is not necessary to perform the corresponding KO test (would be handleSessionExpired_malformedStatusResponseKO) because,
+    in that case, the status response content is not parsed. Only the HTTP status code is relevant.
+     */
 }

--- a/src/test/java/com/payline/payment/oney/service/impl/RefundServiceImplTest.java
+++ b/src/test/java/com/payline/payment/oney/service/impl/RefundServiceImplTest.java
@@ -58,7 +58,6 @@ public class RefundServiceImplTest extends OneyConfigBean {
 
     }
 
-
     @Test
     public void refundRequestTestKO() throws Exception {
         StringResponse responseMocked1 = createStringResponse(200, "OK", "{\"encrypted_message\":\"+l2i0o7hGRh+wJO02++ulzsMg0QfZ1N009CwI1PLZzBnbfv6/Enufe5TriN1gKQkEmbMYU0PMtHdk+eF7boW/lsIc5PmjpFX1E/4MUJGkzI=\"}");
@@ -155,20 +154,6 @@ public class RefundServiceImplTest extends OneyConfigBean {
     }
 
     @Test
-    public void refundRequest_malformedStatusResponseKO() throws PluginTechnicalException {
-        // given a malformed HTTP response received to the status request
-        StringResponse responseMocked = createStringResponse(404, "Bad Request", "[]");
-        Mockito.doReturn(responseMocked).when(httpClient).initiateGetTransactionStatus( Mockito.any(OneyTransactionStatusRequest.class) );
-
-        // when calling the method refundRequest
-        RefundResponse response = service.refundRequest( createDefaultRefundRequest() );
-
-        // then a RefundResponseFailure with the FailureCause.COMMUNICATION_ERROR is returned
-        Assertions.assertTrue( response instanceof RefundResponseFailure);
-        Assertions.assertEquals( FailureCause.COMMUNICATION_ERROR, ((RefundResponseFailure)response).getFailureCause() );
-    }
-
-    @Test
     public void refundRequest_malformedStatusResponseOK() throws PluginTechnicalException {
         // given a malformed HTTP response received to the status request
         StringResponse responseMocked = createStringResponse(200, "OK", "[]");
@@ -181,6 +166,10 @@ public class RefundServiceImplTest extends OneyConfigBean {
         Assertions.assertTrue( response instanceof RefundResponseFailure);
         Assertions.assertEquals( FailureCause.COMMUNICATION_ERROR, ((RefundResponseFailure)response).getFailureCause() );
     }
+    /*
+    It is not necessary to perform the corresponding KO test (would be refundRequest_malformedStatusResponseKO) because,
+    in that case, the status response content is not parsed. Only the HTTP status code is relevant.
+     */
 
     @Test
     public void refundRequest_malformedRefundResponseKO() throws PluginTechnicalException {


### PR DESCRIPTION
PAYLAPMEXT-131 : ajout des échéances 6x, 10x, 12x

Suppression de méthodes de test inutiles (dont 1 générait des appels HTTP réels)