### PR TITLE
PAYLAPMEXT-125, PAYLAPMEXT-150, PAYLAPMEXT-151, PAYLAPMEXT-152, PAYLAPMEXT-154, PAYLAPMEXT-164, PAYLAPMEXT-165

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,7 @@ dependencies {
     testImplementation group: 'org.powermock', name: 'powermock-api-mockito2', version: '2.0.0'
 
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: '5.0.3'
+    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: '5.3.2'
     testImplementation group: 'org.seleniumhq.selenium', name: 'selenium-server', version: '3.13.0'
     testImplementation group: 'org.seleniumhq.selenium', name: 'selenium-support', version: '3.13.0'
 
@@ -66,6 +67,7 @@ dependencies {
     fatJarTest group: 'org.powermock', name: 'powermock-api-mockito2', version: '2.0.0'
     fatJarTest group: 'org.jmockit', name: 'jmockit', version: '1.8'
     fatJarTest group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: '5.0.3'
+    fatJarTest group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: '5.3.2'
     fatJarTest group: 'org.seleniumhq.selenium', name: 'selenium-server', version: '3.13.0'
     fatJarTest group: 'org.seleniumhq.selenium', name: 'selenium-support', version: '3.13.0'
 }

--- a/src/main/java/com/payline/payment/oney/bean/common/PurchaseNotification.java
+++ b/src/main/java/com/payline/payment/oney/bean/common/PurchaseNotification.java
@@ -1,0 +1,38 @@
+package com.payline.payment.oney.bean.common;
+
+import com.google.gson.annotations.SerializedName;
+
+public class PurchaseNotification {
+    @SerializedName("external_reference")
+    private String externalReference;
+
+    @SerializedName("status_label")
+    private String statusLabel;
+    @SerializedName("status_code")
+    private String statusCode;
+    @SerializedName("reason_code")
+    private String reasonCode;
+    @SerializedName("reason_label")
+    private String reasonLabel;
+
+
+    public String getExternalReference() {
+        return externalReference;
+    }
+
+    public String getStatusLabel() {
+        return statusLabel;
+    }
+
+    public String getStatusCode() {
+        return statusCode;
+    }
+
+    public String getReasonCode() {
+        return reasonCode;
+    }
+
+    public String getReasonLabel() {
+        return reasonLabel;
+    }
+}

--- a/src/main/java/com/payline/payment/oney/bean/request/OneyConfirmRequest.java
+++ b/src/main/java/com/payline/payment/oney/bean/request/OneyConfirmRequest.java
@@ -5,11 +5,13 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.payline.payment.oney.bean.common.payment.PaymentData;
+import com.payline.payment.oney.bean.response.OneyNotificationResponse;
 import com.payline.payment.oney.exception.InvalidDataException;
 import com.payline.payment.oney.service.impl.RequestConfigServiceImpl;
 import com.payline.payment.oney.utils.PluginUtils;
 import com.payline.payment.oney.utils.Required;
 import com.payline.pmapi.bean.capture.request.CaptureRequest;
+import com.payline.pmapi.bean.notification.request.NotificationRequest;
 import com.payline.pmapi.bean.payment.request.RedirectionPaymentRequest;
 import com.payline.pmapi.bean.payment.request.TransactionStatusRequest;
 
@@ -88,7 +90,7 @@ public class OneyConfirmRequest extends ParameterizedUrlOneyRequest {
         public Builder(TransactionStatusRequest transactionStatusRequest) throws InvalidDataException {
             String merchantGuidValue = RequestConfigServiceImpl.INSTANCE.getParameterValue(transactionStatusRequest, MERCHANT_GUID_KEY);
 
-            this.withPurchaseReferenceFromOrder( transactionStatusRequest.getOrder() );
+            this.withPurchaseReferenceFromOrder(transactionStatusRequest.getOrder());
             this.merchantRequestId = generateMerchantRequestId(merchantGuidValue);
 
             this.pspGuid = RequestConfigServiceImpl.INSTANCE.getParameterValue(transactionStatusRequest, PSP_GUID_KEY);
@@ -103,7 +105,7 @@ public class OneyConfirmRequest extends ParameterizedUrlOneyRequest {
         public Builder(CaptureRequest captureRequest) throws InvalidDataException {
             String merchantGuidValue = RequestConfigServiceImpl.INSTANCE.getParameterValue(captureRequest, MERCHANT_GUID_KEY);
 
-            this.withPurchaseReferenceFromOrder( captureRequest.getOrder() );
+            this.withPurchaseReferenceFromOrder(captureRequest.getOrder());
             this.merchantRequestId = generateMerchantRequestId(merchantGuidValue);
 
             this.pspGuid = RequestConfigServiceImpl.INSTANCE.getParameterValue(captureRequest, PSP_GUID_KEY);
@@ -113,6 +115,22 @@ public class OneyConfirmRequest extends ParameterizedUrlOneyRequest {
                     .buildForConfirmRequest();
             this.encryptKey = RequestConfigServiceImpl.INSTANCE.getParameterValue(captureRequest, PARTNER_CHIFFREMENT_KEY);
             this.callParameters = PluginUtils.getParametersMap(captureRequest);
+        }
+
+        public Builder(NotificationRequest notificationRequest, OneyNotificationResponse oneyResponse) throws InvalidDataException {
+            this.languageCode = RequestConfigServiceImpl.INSTANCE.getParameterValue(notificationRequest, LANGUAGE_CODE_KEY);
+            this.merchantGuid = oneyResponse.getMerchantGuid();
+            this.merchantRequestId = generateMerchantRequestId(this.merchantGuid);
+            this.paymentData = PaymentData.Builder.aPaymentData()
+                    .withAmount(PluginUtils.getAmount(oneyResponse.getMerchantContext()))
+                    .withCurrency(PluginUtils.getCurrency(oneyResponse.getMerchantContext()))
+                    .buildForConfirmRequest();
+            this.encryptKey = RequestConfigServiceImpl.INSTANCE.getParameterValue(notificationRequest, PARTNER_CHIFFREMENT_KEY);
+
+
+            this.purchaseReference = oneyResponse.getPurchase().getExternalReference();
+            this.pspGuid = RequestConfigServiceImpl.INSTANCE.getParameterValue(notificationRequest, PSP_GUID_KEY);
+            this.callParameters = PluginUtils.getParametersMap(notificationRequest);
         }
 
         public OneyConfirmRequest build() {

--- a/src/main/java/com/payline/payment/oney/bean/request/OneyConfirmRequest.java
+++ b/src/main/java/com/payline/payment/oney/bean/request/OneyConfirmRequest.java
@@ -9,6 +9,7 @@ import com.payline.payment.oney.exception.InvalidDataException;
 import com.payline.payment.oney.service.impl.RequestConfigServiceImpl;
 import com.payline.payment.oney.utils.PluginUtils;
 import com.payline.payment.oney.utils.Required;
+import com.payline.pmapi.bean.capture.request.CaptureRequest;
 import com.payline.pmapi.bean.payment.request.RedirectionPaymentRequest;
 import com.payline.pmapi.bean.payment.request.TransactionStatusRequest;
 
@@ -97,6 +98,21 @@ public class OneyConfirmRequest extends ParameterizedUrlOneyRequest {
                     .buildForConfirmRequest();
             this.encryptKey = RequestConfigServiceImpl.INSTANCE.getParameterValue(transactionStatusRequest, PARTNER_CHIFFREMENT_KEY);
             this.callParameters = PluginUtils.getParametersMap(transactionStatusRequest);
+        }
+
+        public Builder(CaptureRequest captureRequest) throws InvalidDataException {
+            String merchantGuidValue = RequestConfigServiceImpl.INSTANCE.getParameterValue(captureRequest, MERCHANT_GUID_KEY);
+
+            this.withPurchaseReferenceFromOrder( captureRequest.getOrder() );
+            this.merchantRequestId = generateMerchantRequestId(merchantGuidValue);
+
+            this.pspGuid = RequestConfigServiceImpl.INSTANCE.getParameterValue(captureRequest, PSP_GUID_KEY);
+            this.merchantGuid = merchantGuidValue;
+            this.paymentData = PaymentData.Builder.aPaymentData()
+                    .withAmount(createFloatAmount(captureRequest.getAmount().getAmountInSmallestUnit(), captureRequest.getAmount().getCurrency()))
+                    .buildForConfirmRequest();
+            this.encryptKey = RequestConfigServiceImpl.INSTANCE.getParameterValue(captureRequest, PARTNER_CHIFFREMENT_KEY);
+            this.callParameters = PluginUtils.getParametersMap(captureRequest);
         }
 
         public OneyConfirmRequest build() {

--- a/src/main/java/com/payline/payment/oney/bean/request/OneyTransactionStatusRequest.java
+++ b/src/main/java/com/payline/payment/oney/bean/request/OneyTransactionStatusRequest.java
@@ -5,7 +5,9 @@ import com.payline.payment.oney.exception.InvalidDataException;
 import com.payline.payment.oney.service.impl.RequestConfigServiceImpl;
 import com.payline.payment.oney.utils.OneyConstants;
 import com.payline.payment.oney.utils.PluginUtils;
+import com.payline.pmapi.bean.capture.request.CaptureRequest;
 import com.payline.pmapi.bean.payment.Order;
+import com.payline.pmapi.bean.payment.request.RedirectionPaymentRequest;
 import com.payline.pmapi.bean.payment.request.TransactionStatusRequest;
 import com.payline.pmapi.bean.refund.request.RefundRequest;
 
@@ -97,6 +99,26 @@ public class OneyTransactionStatusRequest extends ParameterizedUrlOneyRequest {
                     .withPurchaseReferenceFromOrder( refundRequest.getOrder() )
                     .withEncryptKey(RequestConfigServiceImpl.INSTANCE.getParameterValue(refundRequest, OneyConstants.PARTNER_CHIFFREMENT_KEY))
                     .withCallParameters(PluginUtils.getParametersMap(refundRequest));
+        }
+
+        public OneyTransactionStatusRequest.Builder fromRedirectionPaymentRequest(RedirectionPaymentRequest request) throws InvalidDataException {
+            return OneyTransactionStatusRequest.Builder.aOneyGetStatusRequest()
+                    .withLanguageCode(RequestConfigServiceImpl.INSTANCE.getParameterValue(request, OneyConstants.LANGUAGE_CODE_KEY))
+                    .withMerchantGuid(RequestConfigServiceImpl.INSTANCE.getParameterValue(request, OneyConstants.MERCHANT_GUID_KEY))
+                    .withPspGuid(RequestConfigServiceImpl.INSTANCE.getParameterValue(request, OneyConstants.PSP_GUID_KEY))
+                    .withPurchaseReferenceFromOrder( request.getOrder() )
+                    .withEncryptKey(RequestConfigServiceImpl.INSTANCE.getParameterValue(request, OneyConstants.PARTNER_CHIFFREMENT_KEY))
+                    .withCallParameters(PluginUtils.getParametersMap(request));
+        }
+
+        public OneyTransactionStatusRequest.Builder fromCaptureRequest(CaptureRequest request) throws InvalidDataException {
+            return OneyTransactionStatusRequest.Builder.aOneyGetStatusRequest()
+                    .withLanguageCode(RequestConfigServiceImpl.INSTANCE.getParameterValue(request, OneyConstants.LANGUAGE_CODE_KEY))
+                    .withMerchantGuid(RequestConfigServiceImpl.INSTANCE.getParameterValue(request, OneyConstants.MERCHANT_GUID_KEY))
+                    .withPspGuid(RequestConfigServiceImpl.INSTANCE.getParameterValue(request, OneyConstants.PSP_GUID_KEY))
+                    .withPurchaseReferenceFromOrder( request.getOrder() )
+                    .withEncryptKey(RequestConfigServiceImpl.INSTANCE.getParameterValue(request, OneyConstants.PARTNER_CHIFFREMENT_KEY))
+                    .withCallParameters(PluginUtils.getParametersMap(request));
         }
 
         public OneyTransactionStatusRequest build() {

--- a/src/main/java/com/payline/payment/oney/bean/response/OneyNotificationResponse.java
+++ b/src/main/java/com/payline/payment/oney/bean/response/OneyNotificationResponse.java
@@ -34,6 +34,9 @@ public class OneyNotificationResponse extends OneyResponse {
     @SerializedName("psp_context")
     private String pspContext;
 
+    @SerializedName("merchant_context")
+    private String merchantContext;
+
     public String getLanguageCode() {
         return languageCode;
     }
@@ -58,6 +61,9 @@ public class OneyNotificationResponse extends OneyResponse {
         return pspContext;
     }
 
+    public String getMerchantContext() {
+        return merchantContext;
+    }
 
     public static OneyNotificationResponse createTransactionStatusResponseFromJson(String json, String encryptKey)
             throws DecryptException, MalformedResponseException {

--- a/src/main/java/com/payline/payment/oney/bean/response/OneyNotificationResponse.java
+++ b/src/main/java/com/payline/payment/oney/bean/response/OneyNotificationResponse.java
@@ -1,0 +1,87 @@
+package com.payline.payment.oney.bean.response;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
+import com.google.gson.annotations.SerializedName;
+import com.payline.payment.oney.bean.common.PurchaseNotification;
+import com.payline.payment.oney.bean.common.customer.Customer;
+import com.payline.payment.oney.exception.DecryptException;
+import com.payline.payment.oney.exception.MalformedResponseException;
+import com.payline.payment.oney.utils.properties.service.ConfigPropertiesEnum;
+import com.payline.pmapi.logger.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import static com.payline.payment.oney.utils.OneyConstants.CHIFFREMENT_IS_ACTIVE;
+
+public class OneyNotificationResponse extends OneyResponse {
+    private static final Logger LOGGER = LogManager.getLogger(OneyNotificationResponse.class);
+
+    @SerializedName("language_code")
+    private String languageCode;
+
+    @SerializedName("merchant_guid")
+    private String merchantGuid;
+
+    @SerializedName("oney_request_id")
+    private String oneyRequestId;
+
+    @SerializedName("purchase")
+    private PurchaseNotification purchase;
+
+    @SerializedName("customer")
+    private Customer customer;
+
+    @SerializedName("psp_context")
+    private String pspContext;
+
+    public String getLanguageCode() {
+        return languageCode;
+    }
+
+    public String getMerchantGuid() {
+        return merchantGuid;
+    }
+
+    public String getOneyRequestId() {
+        return oneyRequestId;
+    }
+
+    public PurchaseNotification getPurchase() {
+        return purchase;
+    }
+
+    public Customer getCustomer() {
+        return customer;
+    }
+
+    public String getPspContext() {
+        return pspContext;
+    }
+
+
+    public static OneyNotificationResponse createTransactionStatusResponseFromJson(String json, String encryptKey)
+            throws DecryptException, MalformedResponseException {
+        Gson parser = new Gson();
+
+        OneyNotificationResponse oneyNotificationResponse;
+        try {
+            oneyNotificationResponse = parser.fromJson(json, OneyNotificationResponse.class);
+        }
+        catch( JsonSyntaxException e){
+            LOGGER.error("Unable to parse JSON content", e);
+            throw new MalformedResponseException( e );
+        }
+
+        //Cas reponse est chiffree : on dechiffre la reponse afin de recuperer le statut de la transaction
+        if (Boolean.valueOf(ConfigPropertiesEnum.INSTANCE.get(CHIFFREMENT_IS_ACTIVE))) {
+            String decryptedMessage = OneyResponse.decryptMessage(oneyNotificationResponse.getEncryptedMessage(), encryptKey);
+
+            return parser.fromJson(decryptedMessage, OneyNotificationResponse.class);
+
+        }
+
+        //Sinon on renvoie la reponse parsee
+        return oneyNotificationResponse;
+    }
+
+}

--- a/src/main/java/com/payline/payment/oney/bean/response/OneySuccessPaymentResponse.java
+++ b/src/main/java/com/payline/payment/oney/bean/response/OneySuccessPaymentResponse.java
@@ -5,7 +5,7 @@ import com.google.gson.JsonSyntaxException;
 import com.google.gson.annotations.SerializedName;
 import com.payline.payment.oney.exception.DecryptException;
 import com.payline.payment.oney.exception.HttpCallException;
-import com.payline.payment.oney.exception.MalformedResponseException;
+import com.payline.payment.oney.exception.MalformedJsonException;
 import com.payline.payment.oney.utils.properties.service.ConfigPropertiesEnum;
 import com.payline.pmapi.logger.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -43,7 +43,7 @@ public class OneySuccessPaymentResponse extends OneyResponse {
 
 
     public static OneySuccessPaymentResponse paymentSuccessResponseFromJson(String json, String encryptKey)
-            throws DecryptException, MalformedResponseException {
+            throws DecryptException, MalformedJsonException {
         Gson parser = new Gson();
         OneySuccessPaymentResponse paymentSuccessResponse;
         try {
@@ -51,7 +51,7 @@ public class OneySuccessPaymentResponse extends OneyResponse {
         }
         catch( JsonSyntaxException e){
             LOGGER.error("Unable to parse JSON content", e);
-            throw new MalformedResponseException( e );
+            throw new MalformedJsonException( e );
         }
 
         //Cas reponse est chiffree : on dechiffre la reponse afin de recuperer l'url a renvoyer

--- a/src/main/java/com/payline/payment/oney/bean/response/PaymentErrorResponse.java
+++ b/src/main/java/com/payline/payment/oney/bean/response/PaymentErrorResponse.java
@@ -5,7 +5,7 @@ import com.google.gson.annotations.SerializedName;
 import com.google.gson.reflect.TypeToken;
 import com.payline.payment.oney.bean.common.OneyBean;
 import com.payline.payment.oney.bean.common.OneyError;
-import com.payline.payment.oney.exception.MalformedResponseException;
+import com.payline.payment.oney.exception.MalformedJsonException;
 import com.payline.pmapi.logger.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -34,7 +34,7 @@ public class PaymentErrorResponse extends OneyBean {
     }
 
     public static PaymentErrorResponse paymentErrorResponseFromJson(String json)
-            throws MalformedResponseException {
+            throws MalformedJsonException {
 
         //Specifier le type renvoye
         Type errorListType = new TypeToken<ArrayList<OneyError>>() {
@@ -46,7 +46,7 @@ public class PaymentErrorResponse extends OneyBean {
         }
         catch( JsonSyntaxException e ){
             LOGGER.error("Unable to parse JSON content", e);
-            throw new MalformedResponseException( e );
+            throw new MalformedJsonException( e );
         }
 
         LOGGER.debug("Oney error message : {}", json);

--- a/src/main/java/com/payline/payment/oney/bean/response/TransactionStatusResponse.java
+++ b/src/main/java/com/payline/payment/oney/bean/response/TransactionStatusResponse.java
@@ -5,7 +5,7 @@ import com.google.gson.JsonSyntaxException;
 import com.google.gson.annotations.SerializedName;
 import com.payline.payment.oney.bean.common.PurchaseStatus;
 import com.payline.payment.oney.exception.DecryptException;
-import com.payline.payment.oney.exception.MalformedResponseException;
+import com.payline.payment.oney.exception.MalformedJsonException;
 import com.payline.payment.oney.utils.properties.service.ConfigPropertiesEnum;
 import com.payline.pmapi.logger.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -33,7 +33,7 @@ public class TransactionStatusResponse extends OneyResponse {
 
 
     public static TransactionStatusResponse createTransactionStatusResponseFromJson(String json, String encryptKey)
-            throws DecryptException, MalformedResponseException {
+            throws DecryptException, MalformedJsonException {
         Gson parser = new Gson();
 
         TransactionStatusResponse transactionStatusResponse;
@@ -42,7 +42,7 @@ public class TransactionStatusResponse extends OneyResponse {
         }
         catch( JsonSyntaxException e){
             LOGGER.error("Unable to parse JSON content", e);
-            throw new MalformedResponseException( e );
+            throw new MalformedJsonException( e );
         }
 
         //Cas reponse est chiffree : on dechiffre la reponse afin de recuperer le statut de la transaction

--- a/src/main/java/com/payline/payment/oney/exception/MalformedJsonException.java
+++ b/src/main/java/com/payline/payment/oney/exception/MalformedJsonException.java
@@ -2,7 +2,7 @@ package com.payline.payment.oney.exception;
 
 import com.payline.pmapi.bean.common.FailureCause;
 
-public class MalformedResponseException extends PluginTechnicalException {
+public class MalformedJsonException extends PluginTechnicalException {
 
     private static final String ERROR_CODE = "Unable to parse JSON content";
 
@@ -10,8 +10,17 @@ public class MalformedResponseException extends PluginTechnicalException {
      * Exception constructor
      * @param exception Initial exception thrown
      */
-    public MalformedResponseException(Exception exception) {
+    public MalformedJsonException(Exception exception) {
         super(exception, ERROR_CODE);
+    }
+
+    /**
+     * Exception constructor from a message.
+     * The first argument passed to super() will be logged, the second will be returned to the PM-API.
+     * @param message Error message
+     */
+    public MalformedJsonException( String message ) {
+        super( message, message );
     }
 
     @Override

--- a/src/main/java/com/payline/payment/oney/service/RequestConfigService.java
+++ b/src/main/java/com/payline/payment/oney/service/RequestConfigService.java
@@ -5,6 +5,7 @@ import com.payline.pmapi.bean.buyer.request.BuyerDetailsRequest;
 import com.payline.pmapi.bean.capture.request.CaptureRequest;
 import com.payline.pmapi.bean.configuration.PartnerConfiguration;
 import com.payline.pmapi.bean.configuration.request.ContractParametersCheckRequest;
+import com.payline.pmapi.bean.notification.request.NotificationRequest;
 import com.payline.pmapi.bean.payment.ContractConfiguration;
 import com.payline.pmapi.bean.payment.request.NotifyTransactionStatusRequest;
 import com.payline.pmapi.bean.payment.request.PaymentRequest;
@@ -111,6 +112,16 @@ public interface RequestConfigService {
      * @return the corresponding String value
      */
     String getParameterValue(BuyerDetailsRequest request, String key) throws InvalidDataException;
+
+    /**
+     * Use PARAMETERS_MAP to read a property in ContractConfiguration or in PartnerConfiguration.
+     *
+     * @param request NotificationRequest
+     * @param key     property key
+     * @return the corresponding String value
+     */
+    String getParameterValue(NotificationRequest request, String key) throws InvalidDataException;
+
 
     /**
      * @param partnerConfiguration partner Configuration map

--- a/src/main/java/com/payline/payment/oney/service/impl/BeanAssemblerServiceImpl.java
+++ b/src/main/java/com/payline/payment/oney/service/impl/BeanAssemblerServiceImpl.java
@@ -77,7 +77,7 @@ public class BeanAssemblerServiceImpl implements BeanAssembleService {
                 .withNotificationUrl(environment.getNotificationURL())
                 .withSuccesUrl(environment.getRedirectionReturnURL())
                 .withPendingUrl(environment.getRedirectionReturnURL())
-                .withFailUrl(environment.getRedirectionCancelURL())
+                .withFailUrl(environment.getRedirectionReturnURL())
                 .build();
     }
 

--- a/src/main/java/com/payline/payment/oney/service/impl/CaptureServiceImpl.java
+++ b/src/main/java/com/payline/payment/oney/service/impl/CaptureServiceImpl.java
@@ -1,0 +1,108 @@
+package com.payline.payment.oney.service.impl;
+
+import com.payline.payment.oney.bean.request.OneyConfirmRequest;
+import com.payline.payment.oney.bean.request.OneyTransactionStatusRequest;
+import com.payline.payment.oney.bean.response.TransactionStatusResponse;
+import com.payline.payment.oney.exception.PluginTechnicalException;
+import com.payline.payment.oney.utils.http.OneyHttpClient;
+import com.payline.payment.oney.utils.http.StringResponse;
+import com.payline.pmapi.bean.capture.request.CaptureRequest;
+import com.payline.pmapi.bean.capture.response.CaptureResponse;
+import com.payline.pmapi.bean.capture.response.impl.CaptureResponseFailure;
+import com.payline.pmapi.bean.capture.response.impl.CaptureResponseSuccess;
+import com.payline.pmapi.bean.common.FailureCause;
+import com.payline.pmapi.logger.LogManager;
+import com.payline.pmapi.service.CaptureService;
+import org.apache.logging.log4j.Logger;
+
+import static com.payline.payment.oney.bean.response.TransactionStatusResponse.createTransactionStatusResponseFromJson;
+import static com.payline.payment.oney.utils.OneyConstants.HTTP_OK;
+
+public class CaptureServiceImpl implements CaptureService {
+    private final String ERROR_STATUS = "TRANSACTION STATUS NOT FAVORABLE:";
+    private OneyHttpClient httpClient;
+    private static final Logger LOGGER = LogManager.getLogger(CaptureServiceImpl.class);
+
+    public CaptureServiceImpl() {
+        httpClient = OneyHttpClient.getInstance();
+    }
+
+    @Override
+    public CaptureResponse captureRequest(CaptureRequest captureRequest) {
+        String transactionId = captureRequest.getPartnerTransactionId();
+        boolean isSandbox = captureRequest.getEnvironment().isSandbox();
+        try {
+
+            // call the get status request
+            OneyTransactionStatusRequest oneyTransactionStatusRequest = OneyTransactionStatusRequest.Builder.aOneyGetStatusRequest()
+                    .fromCaptureRequest(captureRequest).build();
+            StringResponse oneyResponse = this.httpClient.initiateGetTransactionStatus(oneyTransactionStatusRequest, isSandbox);
+
+            // check the result
+            if (oneyResponse == null || oneyResponse.getContent() == null || oneyResponse.getCode() != HTTP_OK) {
+                return createFailure(transactionId, "Unable to get transaction status", FailureCause.COMMUNICATION_ERROR);
+
+            } else {
+                // get the payment status
+                TransactionStatusResponse statusResponse = createTransactionStatusResponseFromJson(oneyResponse.getContent(), oneyTransactionStatusRequest.getEncryptKey());
+                if (statusResponse == null || statusResponse.getStatusPurchase() == null) {
+                    return createFailure(transactionId, "Unable to get transaction status", FailureCause.COMMUNICATION_ERROR);
+
+                } else {
+                    // check the status
+                    String getStatus = statusResponse.getStatusPurchase().getStatusCode();
+                    if ("FAVORABLE".equals(getStatus)) {
+                        // confirm the transaction
+                        OneyConfirmRequest confirmRequest = new OneyConfirmRequest.Builder(captureRequest).build();
+                        StringResponse confirmResponse = httpClient.initiateConfirmationPayment(confirmRequest, isSandbox);
+
+                        // check the confirmation response
+                        if (confirmResponse == null || confirmResponse.getContent() == null || confirmResponse.getCode() != HTTP_OK) {
+                            return createFailure(transactionId, "Unable to confirm transaction", FailureCause.COMMUNICATION_ERROR);
+                        }
+                        TransactionStatusResponse confirmTransactionResponse = createTransactionStatusResponseFromJson(confirmResponse.getContent(), oneyTransactionStatusRequest.getEncryptKey());
+
+                        if (confirmTransactionResponse == null || confirmTransactionResponse.getStatusPurchase() == null) {
+                            return createFailure(transactionId, "Unable to confirm transaction", FailureCause.COMMUNICATION_ERROR);
+                        }
+
+                        // check the confirmation response status
+                        String confirmStatus = confirmTransactionResponse.getStatusPurchase().getStatusCode();
+                        if ("FUNDED".equals(confirmStatus)) {
+                            return CaptureResponseSuccess.CaptureResponseSuccessBuilder.aCaptureResponseSuccess()
+                                    .withPartnerTransactionId(captureRequest.getPartnerTransactionId())
+                                    .withStatusCode(confirmStatus)
+                                    .build();
+                        } else {
+                            return createFailure(transactionId, ERROR_STATUS + confirmStatus, FailureCause.REFUSED);
+                        }
+                    } else {
+                        return createFailure(transactionId, ERROR_STATUS + getStatus, FailureCause.REFUSED);
+                    }
+                }
+            }
+
+        } catch (PluginTechnicalException e) {
+            return createFailure(transactionId, e.getTruncatedErrorCodeOrLabel(), e.getFailureCause());
+        }
+    }
+
+    @Override
+    public boolean canMultiple() {
+        return false;
+    }
+
+    @Override
+    public boolean canPartial() {
+        return false;
+    }
+
+    CaptureResponseFailure createFailure(String transactionId, String errorCode, FailureCause cause) {
+        return CaptureResponseFailure.CaptureResponseFailureBuilder.aCaptureResponseFailure()
+                .withPartnerTransactionId(transactionId)
+                .withErrorCode(errorCode)
+                .withFailureCause(cause)
+                .build();
+
+    }
+}

--- a/src/main/java/com/payline/payment/oney/service/impl/ConfigurationServiceImpl.java
+++ b/src/main/java/com/payline/payment/oney/service/impl/ConfigurationServiceImpl.java
@@ -231,11 +231,12 @@ public class ConfigurationServiceImpl implements ConfigurationService {
                         err = OneyError40x.parseJson(stringResponse.getContent());
                         String errMsg = err.getPrintableMessage();
                         LOGGER.error(errMsg);
+                        // it could be the authorisation key
                         if (errMsg.contains("invalid subscription key")) {
                             errors.put(PARTNER_AUTHORIZATION_KEY, err.getMessage());
                         } else {
-                            LOGGER.error("Les paramètres {} et {} ne correspondent pas", PARTNER_AUTHORIZATION_KEY, COUNTRY_CODE_KEY);
-                            errors.put(COUNTRY_CODE_KEY, err.getMessage());
+                            // if not,  it's psp_guid or merchant_guid. we assume psp_guid is correct
+                            errors.put(MERCHANT_GUID_KEY, err.getMessage());
 
                         }
                         break;

--- a/src/main/java/com/payline/payment/oney/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/payline/payment/oney/service/impl/NotificationServiceImpl.java
@@ -1,17 +1,72 @@
 package com.payline.payment.oney.service.impl;
 
+import com.payline.payment.oney.bean.response.OneyNotificationResponse;
+import com.payline.payment.oney.exception.PluginTechnicalException;
+import com.payline.pmapi.bean.common.FailureCause;
+import com.payline.pmapi.bean.common.FailureTransactionStatus;
+import com.payline.pmapi.bean.common.SuccessTransactionStatus;
+import com.payline.pmapi.bean.common.TransactionStatus;
 import com.payline.pmapi.bean.notification.request.NotificationRequest;
 import com.payline.pmapi.bean.notification.response.NotificationResponse;
 import com.payline.pmapi.bean.notification.response.impl.IgnoreNotificationResponse;
+import com.payline.pmapi.bean.notification.response.impl.TransactionStateChangedResponse;
 import com.payline.pmapi.bean.payment.request.NotifyTransactionStatusRequest;
 import com.payline.pmapi.service.NotificationService;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Date;
+import java.util.stream.Collectors;
 
 public class NotificationServiceImpl implements NotificationService {
-
+    private static final Logger LOGGER = LogManager.getLogger(NotificationServiceImpl.class);
 
     @Override
     public NotificationResponse parse(NotificationRequest notificationRequest) {
-        return new IgnoreNotificationResponse();
+        // init data
+        String transactionId = "UNKNOWN";
+        String partnerTransactionId = "UNKNOWN";
+        TransactionStateChangedResponse.Action action = TransactionStateChangedResponse.Action.AUTHOR_AND_CAPTURE;
+        TransactionStatus status = new FailureTransactionStatus();
+
+        // get the body of the request
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(notificationRequest.getContent(), "UTF-8"))) {
+            String bodyResponse = br.lines().collect(Collectors.joining(System.lineSeparator()));
+            final String key = "";  // unable to get the true key (see PAYLAPMEXT-150)
+
+            // extract all needed data
+            OneyNotificationResponse oneyResponse = OneyNotificationResponse.createTransactionStatusResponseFromJson(bodyResponse, key);
+            transactionId = oneyResponse.getPspContext();
+            partnerTransactionId = oneyResponse.getPurchase().getExternalReference();
+
+
+            // check the status
+            String paymentStatus = oneyResponse.getPurchase().getStatusLabel();
+            if ("FUNDED".equals(paymentStatus)) {
+                status = new SuccessTransactionStatus();
+            } else if ("REFUSED".equals(paymentStatus) || "ABORTED".equals(paymentStatus)) {
+                status = new FailureTransactionStatus(FailureCause.REFUSED);
+            } else {
+                return new IgnoreNotificationResponse();
+            }
+
+
+        } catch (IOException e) {
+            LOGGER.error("Unable to read the notification request's body");
+        } catch (PluginTechnicalException e) {
+            LOGGER.error("Unable to get infomation needed to know the transaction status");
+        }
+
+        return TransactionStateChangedResponse.TransactionStateChangedResponseBuilder.aTransactionStateChangedResponse()
+                .withTransactionId(transactionId)
+                .withPartnerTransactionId(partnerTransactionId)
+                .withStatusDate(new Date())
+                .withAction(action)
+                .withTransactionStatus(status)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/payline/payment/oney/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/payline/payment/oney/service/impl/NotificationServiceImpl.java
@@ -1,7 +1,13 @@
 package com.payline.payment.oney.service.impl;
 
+import com.payline.payment.oney.bean.request.OneyConfirmRequest;
 import com.payline.payment.oney.bean.response.OneyNotificationResponse;
+import com.payline.payment.oney.bean.response.TransactionStatusResponse;
 import com.payline.payment.oney.exception.PluginTechnicalException;
+import com.payline.payment.oney.utils.OneyConstants;
+import com.payline.payment.oney.utils.PluginUtils;
+import com.payline.payment.oney.utils.http.OneyHttpClient;
+import com.payline.payment.oney.utils.http.StringResponse;
 import com.payline.pmapi.bean.common.FailureCause;
 import com.payline.pmapi.bean.common.FailureTransactionStatus;
 import com.payline.pmapi.bean.common.SuccessTransactionStatus;
@@ -21,8 +27,16 @@ import java.io.InputStreamReader;
 import java.util.Date;
 import java.util.stream.Collectors;
 
+import static com.payline.payment.oney.bean.response.TransactionStatusResponse.createTransactionStatusResponseFromJson;
+import static com.payline.payment.oney.utils.OneyConstants.HTTP_OK;
+
 public class NotificationServiceImpl implements NotificationService {
     private static final Logger LOGGER = LogManager.getLogger(NotificationServiceImpl.class);
+    private OneyHttpClient httpClient;
+
+    public NotificationServiceImpl() {
+        httpClient = OneyHttpClient.getInstance();
+    }
 
     @Override
     public NotificationResponse parse(NotificationRequest notificationRequest) {
@@ -35,7 +49,7 @@ public class NotificationServiceImpl implements NotificationService {
         // get the body of the request
         try (BufferedReader br = new BufferedReader(new InputStreamReader(notificationRequest.getContent(), "UTF-8"))) {
             String bodyResponse = br.lines().collect(Collectors.joining(System.lineSeparator()));
-            final String key = "";  // unable to get the true key (see PAYLAPMEXT-150)
+            final String key = RequestConfigServiceImpl.INSTANCE.getParameterValue(notificationRequest, OneyConstants.PARTNER_CHIFFREMENT_KEY);
 
             // extract all needed data
             OneyNotificationResponse oneyResponse = OneyNotificationResponse.createTransactionStatusResponseFromJson(bodyResponse, key);
@@ -43,14 +57,57 @@ public class NotificationServiceImpl implements NotificationService {
             partnerTransactionId = oneyResponse.getPurchase().getExternalReference();
 
 
-            // check the status
+            // check the payment status
             String paymentStatus = oneyResponse.getPurchase().getStatusLabel();
-            if ("FUNDED".equals(paymentStatus)) {
-                status = new SuccessTransactionStatus();
-            } else if ("REFUSED".equals(paymentStatus) || "ABORTED".equals(paymentStatus)) {
-                status = new FailureTransactionStatus(FailureCause.REFUSED);
-            } else {
-                return new IgnoreNotificationResponse();
+            switch (paymentStatus) {
+                case "FUNDED":
+                    status = new SuccessTransactionStatus();
+                    break;
+                case "FAVORABLE":
+                    // if captureNow => does to comfirm call
+                    if (PluginUtils.isCaptureNow(oneyResponse.getMerchantContext())) {
+                        // confirm the request
+                        OneyConfirmRequest confirmRequest = new OneyConfirmRequest.Builder(notificationRequest, oneyResponse)
+                                .build();
+                        StringResponse confirmResponse = httpClient.initiateConfirmationPayment(confirmRequest, notificationRequest.getEnvironment().isSandbox());
+
+
+                        // check the confirmation response
+                        if (confirmResponse == null || confirmResponse.getContent() == null || confirmResponse.getCode() != HTTP_OK) {
+                            // unable to read the response
+                            LOGGER.error("Unable to read the confirmation response");
+                            status = new FailureTransactionStatus(FailureCause.COMMUNICATION_ERROR);
+                            break;
+                        }
+
+                        TransactionStatusResponse confirmTransactionResponse = createTransactionStatusResponseFromJson(confirmResponse.getContent(), key);
+                        if (confirmTransactionResponse == null || confirmTransactionResponse.getStatusPurchase() == null) {
+                            // unable to read the payment status
+                            LOGGER.error("Unable to read the comfiration response transaction status");
+                            status = new FailureTransactionStatus(FailureCause.COMMUNICATION_ERROR);
+                            break;
+                        }
+
+                        // check the confirmation response status
+                        String confirmStatus = confirmTransactionResponse.getStatusPurchase().getStatusCode();
+                        if ("FUNDED".equals(confirmStatus)) {
+                            // success
+                            status = new SuccessTransactionStatus();
+                        } else {
+                            status = new FailureTransactionStatus(FailureCause.REFUSED);
+                        }
+                    }
+                    status = new SuccessTransactionStatus();
+
+                    break;
+                case "REFUSED":
+                    status = new FailureTransactionStatus(FailureCause.REFUSED);
+                    break;
+                case "ABORTED":
+                    status = new FailureTransactionStatus(FailureCause.CANCEL);
+                    break;
+                default:
+                    return new IgnoreNotificationResponse();
             }
 
 

--- a/src/main/java/com/payline/payment/oney/service/impl/PaymentServiceImpl.java
+++ b/src/main/java/com/payline/payment/oney/service/impl/PaymentServiceImpl.java
@@ -59,6 +59,7 @@ public class PaymentServiceImpl implements PaymentService {
             final NavigationData navigationData = beanAssembleService.assembleNavigationData(paymentRequest);
             final Customer customer = beanAssembleService.assembleCustomer(paymentRequest);
             final Purchase purchase = beanAssembleService.assemblePurchase(paymentRequest);
+            String merchantContext = PluginUtils.createMerchantContext(paymentRequest);
 
             final OneyPaymentRequest oneyRequest = OneyPaymentRequest.Builder.aOneyPaymentRequest()
                     .withLanguageCode(language)
@@ -74,6 +75,7 @@ public class PaymentServiceImpl implements PaymentService {
                     .withMerchantContext(paymentRequest.getSoftDescriptor())
                     .withPspContext(paymentRequest.getTransactionId())
                     .withCallParameters(PluginUtils.getParametersMap(paymentRequest))
+                    .withMerchantContext(merchantContext)// adding data to merchantContext field to get it later on the notification
                     .build();
 
             final StringResponse oneyResponse = httpClient.initiatePayment(oneyRequest, paymentRequest.getEnvironment().isSandbox());

--- a/src/main/java/com/payline/payment/oney/service/impl/RequestConfigServiceImpl.java
+++ b/src/main/java/com/payline/payment/oney/service/impl/RequestConfigServiceImpl.java
@@ -6,6 +6,7 @@ import com.payline.payment.oney.utils.OneyConstants;
 import com.payline.pmapi.bean.buyer.request.BuyerDetailsRequest;
 import com.payline.pmapi.bean.capture.request.CaptureRequest;
 import com.payline.pmapi.bean.configuration.request.ContractParametersCheckRequest;
+import com.payline.pmapi.bean.notification.request.NotificationRequest;
 import com.payline.pmapi.bean.payment.request.NotifyTransactionStatusRequest;
 import com.payline.pmapi.bean.payment.request.PaymentRequest;
 import com.payline.pmapi.bean.payment.request.TransactionStatusRequest;
@@ -180,6 +181,20 @@ public enum RequestConfigServiceImpl implements RequestConfigService {
 
     @Override
     public String getParameterValue(BuyerDetailsRequest request, String key) throws InvalidDataException {
+        PaylineParameterType paylineParameterType = PARAMETERS_MAP.get(key);
+        if (PaylineParameterType.CONTRACT_CONFIGURATION_PARAMETER == paylineParameterType) {
+            return safeGetValue(request.getContractConfiguration(), key);
+        } else if (PaylineParameterType.PARTNER_CONFIGURATION_PARAMETER == paylineParameterType) {
+            return safeGetValue(request.getPartnerConfiguration(), key);
+        } else if (PaylineParameterType.EXT_PARTNER_CONFIGURATION_PARAMETER == paylineParameterType) {
+            String ext = safeGetValue(request.getContractConfiguration(), OneyConstants.COUNTRY_CODE_KEY);
+            return safeGetValue(request.getPartnerConfiguration(), key, ext);
+        }
+        return null;
+    }
+
+    @Override
+    public String getParameterValue(NotificationRequest request, String key) throws InvalidDataException {
         PaylineParameterType paylineParameterType = PARAMETERS_MAP.get(key);
         if (PaylineParameterType.CONTRACT_CONFIGURATION_PARAMETER == paylineParameterType) {
             return safeGetValue(request.getContractConfiguration(), key);

--- a/src/main/java/com/payline/payment/oney/utils/OneyErrorHandler.java
+++ b/src/main/java/com/payline/payment/oney/utils/OneyErrorHandler.java
@@ -46,6 +46,7 @@ public class OneyErrorHandler {
             case 408:
             case 429:
             case 503:
+            case 504:
                 paylineCause = FailureCause.COMMUNICATION_ERROR;
                 break;
             case 400:

--- a/src/main/java/com/payline/payment/oney/utils/PluginUtils.java
+++ b/src/main/java/com/payline/payment/oney/utils/PluginUtils.java
@@ -6,6 +6,7 @@ import com.payline.payment.oney.exception.InvalidFieldFormatException;
 import com.payline.payment.oney.exception.InvalidRequestException;
 import com.payline.payment.oney.service.impl.RequestConfigServiceImpl;
 import com.payline.payment.oney.utils.properties.service.ConfigPropertiesEnum;
+import com.payline.pmapi.bean.capture.request.CaptureRequest;
 import com.payline.pmapi.bean.common.Buyer;
 import com.payline.pmapi.bean.configuration.request.ContractParametersCheckRequest;
 import com.payline.pmapi.bean.payment.request.PaymentRequest;
@@ -412,6 +413,20 @@ public class PluginUtils {
         }
 
         return parametersMap;
+    }
+
+    /**
+     * Buid a map with all needed parameters for HTTP calls
+     *
+     * @param captureRequest Payline captureRequest
+     * @return the ParametersMap
+     */
+    public static Map<String, String> getParametersMap(CaptureRequest captureRequest) throws InvalidDataException {
+
+        String authorization = RequestConfigServiceImpl.INSTANCE.getParameterValue(captureRequest, PARTNER_AUTHORIZATION_KEY);
+        String url = RequestConfigServiceImpl.INSTANCE.getParameterValue(captureRequest, PARTNER_API_URL);
+        String coutryCode = RequestConfigServiceImpl.INSTANCE.getParameterValue(captureRequest, COUNTRY_CODE_KEY);
+        return getParametersMap(authorization, url, coutryCode);
     }
 
 

--- a/src/main/java/com/payline/payment/oney/utils/properties/constants/ConfigurationConstants.java
+++ b/src/main/java/com/payline/payment/oney/utils/properties/constants/ConfigurationConstants.java
@@ -17,6 +17,11 @@ public class ConfigurationConstants {
     public static final String RELEASE_DATE = "release.date";
     public static final String RELEASE_VERSION = "release.version";
     public static final String RELEASE_PROPERTIES = "release.properties";
+
+
+    public static final String CAPTURE_NOW = "CN";
+    public static final String CAPTURE_LATER = "CL";
+    public static final String SEPARATOR = "!";
 }
 
 

--- a/src/main/resources/META-INF/services/com.payline.pmapi.service.CaptureService
+++ b/src/main/resources/META-INF/services/com.payline.pmapi.service.CaptureService
@@ -1,0 +1,1 @@
+com.payline.payment.oney.service.impl.CaptureServiceImpl

--- a/src/test/java/com/payline/payment/oney/bean/common/NavigationDataTest.java
+++ b/src/test/java/com/payline/payment/oney/bean/common/NavigationDataTest.java
@@ -25,7 +25,7 @@ public class NavigationDataTest {
     }
 
     @Test
-    public void buildNavigationData() throws Exception {
+    public void buildNavigationData() {
         navigationData = NavigationData.Builder.aNavigationDataBuilder()
                 .withFailUrl("fail/url/")
                 .withSuccesUrl("success/url/")
@@ -47,7 +47,7 @@ public class NavigationDataTest {
         Assertions.assertEquals("http://google.com/", navigationData.getNotificationUrl());
         Assertions.assertEquals("https://succesurl.com/", navigationData.getPendingUrl());
         Assertions.assertEquals("https://succesurl.com/", navigationData.getSuccessUrl());
-        Assertions.assertEquals("http://localhost/cancelurl.com/", navigationData.getFailUrl());
+        Assertions.assertEquals("https://succesurl.com/", navigationData.getFailUrl());
     }
 
     @Test

--- a/src/test/java/com/payline/payment/oney/bean/response/OneyFailureResponseTest.java
+++ b/src/test/java/com/payline/payment/oney/bean/response/OneyFailureResponseTest.java
@@ -1,6 +1,6 @@
 package com.payline.payment.oney.bean.response;
 
-import com.payline.payment.oney.exception.MalformedResponseException;
+import com.payline.payment.oney.exception.MalformedJsonException;
 import com.payline.payment.oney.utils.OneyErrorHandler;
 import com.payline.payment.oney.utils.http.StringResponse;
 import com.payline.pmapi.bean.common.FailureCause;
@@ -18,7 +18,7 @@ public class OneyFailureResponseTest {
     private static final String SEP = " - ";
 
     @Test
-    public void testOneyFailureResponse() throws MalformedResponseException {
+    public void testOneyFailureResponse() throws MalformedJsonException {
         StringResponse stringResponse = createStringResponse(400, "Bad request", "{\"Payments_Error_Response\":{\"error_list \":[{\"field\":\"purchase.delivery.delivery_address.country_code\",\"error_code\":\"ERR_02\",\"error_label\":\"Size of the field should be equal to [3] characters\"},{\"field\":\"purchase.item_list.category_code\",\"error_code\":\"ERR_04\",\"error_label\":\"Value of the field is invalid [{Integer}]\"},{\"field\":\"purchase.item_list.category_code\",\"error_code\":\"ERR_04\",\"error_label\":\"Value of the field is invalid [{Integer}]\"},{\"field\":\"customer.customer_address.country_code\",\"error_code\":\"ERR_02\",\"error_label\":\"Size of the field should be equal to [3] characters\"},{\"field\":\"payment.payment_type\",\"error_code\":\"ERR_03\",\"error_label\":\"Format of the field is invalid [{Integer}]\"}]}}");
 
         OneyFailureResponse failureCause = new OneyFailureResponse(stringResponse.getCode(), stringResponse.getMessage(), stringResponse.getContent(), paymentErrorResponseFromJson(stringResponse.getContent()));
@@ -32,7 +32,7 @@ public class OneyFailureResponseTest {
 
 
     @Test
-    public void tesHandleOneyFailureResponseFromCause2() throws MalformedResponseException {
+    public void tesHandleOneyFailureResponseFromCause2() throws MalformedJsonException {
         String json = "{\"Payments_Error_Response\":{\"error_list \":[{\"field\":\"payment.business_transaction.code\",\"error_code\":\"ERR_02\",\"error_label\":\"Size of the field should be less than or equal to [5] characters\"}]}}";
 
         StringResponse stringResponse = createStringResponse(400, "Bad request", json);
@@ -57,7 +57,7 @@ public class OneyFailureResponseTest {
 
 
     @Test
-    public void paylineFailureResponse_PAYLAPMEXT_98() throws MalformedResponseException {
+    public void paylineFailureResponse_PAYLAPMEXT_98() throws MalformedJsonException {
         String json = "{\"Payments_Error_Response\":{\"error_list\":[{\"error\":{\"field\":\"language_code\",\"error_code\":\"ERR_04\",\"error_label\":\"Value of the field is invalid [{String}]\"}},{\"error\":{\"field\":\"Brand_language_code\",\"error_code\":\"ERR_04\",\"error_label\":\"Value of the field is invalid [{String}]\"}},{\"error\":{\"field\":\"customer.language_code\",\"error_code\":\"ERR_04\",\"error_label\":\"Value of the field is invalid [{String}]\"}}]}}";
 
         StringResponse stringResponse = createStringResponse(400, "Bad request", json);
@@ -84,7 +84,7 @@ public class OneyFailureResponseTest {
 
 
     @Test
-    public void paylineFailureResponse_truncate() throws MalformedResponseException {
+    public void paylineFailureResponse_truncate() throws MalformedJsonException {
         String json = "{\"Payments_Error_Response\":{\"error_list\":[{\"error\":{\"field\":\"language_code_language_code_language_code_language_code\",\"error_code\":\"ERR_04\",\"error_label\":\"Value of the field is invalid [{String}]\"}},{\"error\":{\"field\":\"Brand_language_code\",\"error_code\":\"ERR_04\",\"error_label\":\"Value of the field is invalid [{String}]\"}},{\"error\":{\"field\":\"customer.language_code\",\"error_code\":\"ERR_04\",\"error_label\":\"Value of the field is invalid [{String}]\"}}]}}";
 
         StringResponse stringResponse = createStringResponse(400, "Bad request", json);

--- a/src/test/java/com/payline/payment/oney/bean/response/TransactionStatusResponseTest.java
+++ b/src/test/java/com/payline/payment/oney/bean/response/TransactionStatusResponseTest.java
@@ -1,7 +1,7 @@
 package com.payline.payment.oney.bean.response;
 
 import com.payline.payment.oney.exception.DecryptException;
-import com.payline.payment.oney.exception.MalformedResponseException;
+import com.payline.payment.oney.exception.MalformedJsonException;
 import com.payline.payment.oney.utils.OneyConfigBean;
 import com.payline.payment.oney.utils.http.StringResponse;
 import org.junit.jupiter.api.Assertions;
@@ -18,7 +18,7 @@ public class TransactionStatusResponseTest extends OneyConfigBean {
 
 
     @Test
-    public void transactionStatusNotEncrypted() throws DecryptException, MalformedResponseException {
+    public void transactionStatusNotEncrypted() throws DecryptException, MalformedJsonException {
         StringResponse encryptedResponse = createStringResponse(400, "OK", "{\"purchase\":{\"status_code\":\"PENDING\",\"status_label\":\"Waiting for customer validation\"}}");
 
 
@@ -32,7 +32,7 @@ public class TransactionStatusResponseTest extends OneyConfigBean {
     }
 
     @Test
-    public void transactionStatusEncrypted() throws DecryptException, MalformedResponseException {
+    public void transactionStatusEncrypted() throws DecryptException, MalformedJsonException {
         StringResponse encryptedResponse = createStringResponse(200, "OK", "{\"encrypted_message\":\"+l2i0o7hGRh+wJO02++ul3aakmok0anPtpBvW1vZ3e83c7evaIMgKsuqlJpPjg407AoMkFm94736cZcnpC81qiX4V8n9IxMD1E50QBAOkMZ1S8Pf90kxhXSDe3wt4J13\"}");
 
 

--- a/src/test/java/com/payline/payment/oney/service/impl/CaptureServiceImplTest.java
+++ b/src/test/java/com/payline/payment/oney/service/impl/CaptureServiceImplTest.java
@@ -1,0 +1,77 @@
+package com.payline.payment.oney.service.impl;
+
+import com.payline.payment.oney.exception.HttpCallException;
+import com.payline.payment.oney.utils.TestUtils;
+import com.payline.payment.oney.utils.http.OneyHttpClient;
+import com.payline.payment.oney.utils.http.StringResponse;
+import com.payline.pmapi.bean.capture.request.CaptureRequest;
+import com.payline.pmapi.bean.capture.response.CaptureResponse;
+import com.payline.pmapi.bean.capture.response.impl.CaptureResponseFailure;
+import com.payline.pmapi.bean.capture.response.impl.CaptureResponseSuccess;
+import com.payline.pmapi.service.CaptureService;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.mockito.InjectMocks;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+
+import static com.payline.payment.oney.utils.TestUtils.createStringResponse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class CaptureServiceImplTest {
+
+    @InjectMocks
+    CaptureService service;
+
+    @Spy
+    OneyHttpClient client;
+
+    @BeforeAll
+    public void setup() {
+        service = new CaptureServiceImpl();
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    void captureRequest() throws Exception {
+        StringResponse responseMockedGet = createStringResponse(200, "OK", "{\"purchase\":{\"status_code\":\"FAVORABLE\",\"status_label\":\"a label\"}}");
+        StringResponse responseMockedConfirm = createStringResponse(200, "OK", "{\"purchase\":{\"status_code\":\"FUNDED\",\"status_label\":\"a label\"}}");
+
+        Mockito.doReturn(responseMockedGet).when(client).initiateGetTransactionStatus(any(), anyBoolean());
+        Mockito.doReturn(responseMockedConfirm).when(client).initiateConfirmationPayment(any(), anyBoolean());
+
+        CaptureRequest request = TestUtils.createDefaultCaptureRequest();
+
+        CaptureResponse response = service.captureRequest(request);
+        Assertions.assertEquals(CaptureResponseSuccess.class, response.getClass());
+    }
+
+    @Test
+    void captureRequestError() throws Exception{
+        StringResponse responseMocked = createStringResponse(200, "OK", "{\"purchase\":{\"status_code\":\"REFUSED\",\"status_label\":\"a label\"}}");
+
+        Mockito.doReturn(responseMocked).when(client).initiateGetTransactionStatus(any(), anyBoolean());
+        Mockito.doReturn(responseMocked).when(client).initiateConfirmationPayment(any(), anyBoolean());
+
+        CaptureRequest request = TestUtils.createDefaultCaptureRequest();
+
+        CaptureResponse response = service.captureRequest(request);
+        Assertions.assertEquals(CaptureResponseFailure.class, response.getClass());
+    }
+
+    @Test
+    void captureRequestException() throws Exception{
+        Mockito.doThrow(new HttpCallException("foo", "bar")).when(client).initiateGetTransactionStatus(any(), anyBoolean());
+
+        CaptureRequest request = TestUtils.createDefaultCaptureRequest();
+
+        CaptureResponse response = service.captureRequest(request);
+        Assertions.assertEquals(CaptureResponseFailure.class, response.getClass());
+    }
+
+}

--- a/src/test/java/com/payline/payment/oney/service/impl/NotificationServiceTest.java
+++ b/src/test/java/com/payline/payment/oney/service/impl/NotificationServiceTest.java
@@ -88,6 +88,7 @@ public class NotificationServiceTest extends OneyConfigBean {
                 .withContent(new ByteArrayInputStream(content.getBytes()))
                 .withContractConfiguration(TestUtils.createContractConfiguration())
                 .withPartnerConfiguration(TestUtils.createDefaultPartnerConfiguration())
+                .withEnvironment(TestUtils.TEST_ENVIRONMENT)
                 .build();
 
         StringResponse responseMockedConfirm = createStringResponse(200, "OK", "{\"purchase\":{\"status_code\":\"FUNDED\",\"status_label\":\"a label\"}}");
@@ -130,6 +131,7 @@ public class NotificationServiceTest extends OneyConfigBean {
                 .withContent(new ByteArrayInputStream(content.getBytes()))
                 .withContractConfiguration(TestUtils.createContractConfiguration())
                 .withPartnerConfiguration(TestUtils.createDefaultPartnerConfiguration())
+                .withEnvironment(TestUtils.TEST_ENVIRONMENT)
                 .build();
 
         NotificationResponse response = service.parse(request);
@@ -146,6 +148,7 @@ public class NotificationServiceTest extends OneyConfigBean {
                 .withContent(new ByteArrayInputStream("foo".getBytes()))
                 .withContractConfiguration(TestUtils.createContractConfiguration())
                 .withPartnerConfiguration(TestUtils.createDefaultPartnerConfiguration())
+                .withEnvironment(TestUtils.TEST_ENVIRONMENT)
                 .build();
 
         NotificationResponse response = service.parse(request);

--- a/src/test/java/com/payline/payment/oney/service/impl/NotificationServiceTest.java
+++ b/src/test/java/com/payline/payment/oney/service/impl/NotificationServiceTest.java
@@ -1,6 +1,9 @@
 package com.payline.payment.oney.service.impl;
 
 import com.payline.payment.oney.utils.OneyConfigBean;
+import com.payline.payment.oney.utils.TestUtils;
+import com.payline.payment.oney.utils.http.OneyHttpClient;
+import com.payline.payment.oney.utils.http.StringResponse;
 import com.payline.pmapi.bean.common.FailureTransactionStatus;
 import com.payline.pmapi.bean.common.SuccessTransactionStatus;
 import com.payline.pmapi.bean.notification.request.NotificationRequest;
@@ -14,26 +17,39 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
 
 import java.io.ByteArrayInputStream;
 import java.util.HashMap;
 import java.util.stream.Stream;
 
+import static com.payline.payment.oney.utils.TestUtils.createStringResponse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class NotificationServiceTest extends OneyConfigBean {
 
+    @InjectMocks
     NotificationServiceImpl service;
+
+    @Spy
+    OneyHttpClient client;
 
     @BeforeAll
     public void setup() {
         service = new NotificationServiceImpl();
-
+        MockitoAnnotations.initMocks(this);
 
     }
 
     private static Stream<Arguments> parseSet() {
         return Stream.of(
                 Arguments.of("FUNDED", SuccessTransactionStatus.class),
+                Arguments.of("FAVORABLE", SuccessTransactionStatus.class),
                 Arguments.of("REFUSED", FailureTransactionStatus.class),
                 Arguments.of("ABORTED", FailureTransactionStatus.class)
         );
@@ -41,7 +57,7 @@ public class NotificationServiceTest extends OneyConfigBean {
 
     @ParameterizedTest
     @MethodSource("parseSet")
-    void parse(String OneyStatus, Class expectedClass) {
+    void parse(String OneyStatus, Class expectedClass) throws Exception {
         String content = "{" +
                 "  \"language_code\": \"FR\"," +
                 "  \"merchant_guid\": \"anId\"," +
@@ -60,7 +76,7 @@ public class NotificationServiceTest extends OneyConfigBean {
                 "  \"customer\": {" +
                 "    \"customer_external_code\": \"aCode\"" +
                 "  }," +
-                "  \"merchant_context\": \"aContext\"," +
+                "  \"merchant_context\": \"CN!1000!EUR\"," +
                 "  \"psp_context\": \"1234\"" +
                 "}";
         content = content.replace("XXXXXX", OneyStatus);
@@ -70,7 +86,12 @@ public class NotificationServiceTest extends OneyConfigBean {
                 .withPathInfo("thisIsAPath")
                 .withHttpMethod("POST")
                 .withContent(new ByteArrayInputStream(content.getBytes()))
+                .withContractConfiguration(TestUtils.createContractConfiguration())
+                .withPartnerConfiguration(TestUtils.createDefaultPartnerConfiguration())
                 .build();
+
+        StringResponse responseMockedConfirm = createStringResponse(200, "OK", "{\"purchase\":{\"status_code\":\"FUNDED\",\"status_label\":\"a label\"}}");
+        Mockito.doReturn(responseMockedConfirm).when(client).initiateConfirmationPayment(any(), anyBoolean());
 
         NotificationResponse response = service.parse(request);
         TransactionStateChangedResponse transactionStateChangedResponse = (TransactionStateChangedResponse) response;
@@ -101,12 +122,14 @@ public class NotificationServiceTest extends OneyConfigBean {
                 "  \"merchant_context\": \"aContext\"," +
                 "  \"psp_context\": \"1234\"" +
                 "}";
-        content = content.replace("XXXXXX", "FAVORABLE");
+        content = content.replace("XXXXXX", "ANYTHING");
         NotificationRequest request = NotificationRequest.NotificationRequestBuilder.aNotificationRequest()
                 .withHeaderInfos(new HashMap<>())
                 .withPathInfo("thisIsAPath")
                 .withHttpMethod("POST")
                 .withContent(new ByteArrayInputStream(content.getBytes()))
+                .withContractConfiguration(TestUtils.createContractConfiguration())
+                .withPartnerConfiguration(TestUtils.createDefaultPartnerConfiguration())
                 .build();
 
         NotificationResponse response = service.parse(request);
@@ -121,6 +144,8 @@ public class NotificationServiceTest extends OneyConfigBean {
                 .withPathInfo("thisIsAPath")
                 .withHttpMethod("POST")
                 .withContent(new ByteArrayInputStream("foo".getBytes()))
+                .withContractConfiguration(TestUtils.createContractConfiguration())
+                .withPartnerConfiguration(TestUtils.createDefaultPartnerConfiguration())
                 .build();
 
         NotificationResponse response = service.parse(request);

--- a/src/test/java/com/payline/payment/oney/service/impl/PaymentWithRedirectionServiceTest.java
+++ b/src/test/java/com/payline/payment/oney/service/impl/PaymentWithRedirectionServiceTest.java
@@ -1,7 +1,6 @@
 package com.payline.payment.oney.service.impl;
 
 import com.payline.payment.oney.bean.request.OneyConfirmRequest;
-import com.payline.payment.oney.bean.request.OneyPaymentRequest;
 import com.payline.payment.oney.bean.request.OneyTransactionStatusRequest;
 import com.payline.payment.oney.exception.HttpCallException;
 import com.payline.payment.oney.exception.PluginTechnicalException;
@@ -15,14 +14,16 @@ import com.payline.pmapi.bean.payment.response.PaymentResponse;
 import com.payline.pmapi.bean.payment.response.impl.PaymentResponseFailure;
 import com.payline.pmapi.bean.payment.response.impl.PaymentResponseOnHold;
 import com.payline.pmapi.bean.payment.response.impl.PaymentResponseSuccess;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.mockito.InjectMocks;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 
 import static com.payline.payment.oney.utils.TestUtils.*;
-import static com.payline.payment.oney.utils.TestUtils.createDefaultTransactionStatusRequest;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -120,9 +121,12 @@ public class PaymentWithRedirectionServiceTest extends OneyConfigBean {
     }
 
     @Test
-    public void finalizeRedirectionPaymentEncryptedOK() throws HttpCallException {
-        StringResponse responseMocked = createStringResponse(200, "OK", "{\"encrypted_message\":\"+l2i0o7hGRh+wJO02++ulzsMg0QfZ1N009CwI1PLZzBnbfv6/Enufe5TriN1gKQkEmbMYU0PMtHdk+eF7boW/lsIc5PmjpFX1E/4MUJGkzI=\"}");
-        Mockito.doReturn(responseMocked).when(httpClient).doPost(Mockito.anyString(), Mockito.anyString(), Mockito.anyMap());
+    public void finalizeRedirectionPaymentEncryptedOK() throws Exception {
+        StringResponse responseMocked = createStringResponse(200, "OK", "{\"encrypted_message\":\"+l2i0o7hGRh+wJO02++ul/bQBJ3C1/cyjmvmAAmMq9gLttO54jS+b/UB/MPwY6YeiFWc7TtYNuIHJF3Grkl2/O4B6r4zkTpus9DrEZIou4aE8tfX+G43n2zFDAoYG3u3\"}");
+        StringResponse responseMockedConfirmation = createStringResponse(200, "OK", "{\"encrypted_message\":\"+l2i0o7hGRh+wJO02++ulzsMg0QfZ1N009CwI1PLZzBnbfv6/Enufe5TriN1gKQkEmbMYU0PMtHdk+eF7boW/lsIc5PmjpFX1E/4MUJGkzI=\"}");
+
+        Mockito.doReturn(responseMocked).when(httpClient).initiateGetTransactionStatus( Mockito.any(), anyBoolean() );
+        Mockito.doReturn(responseMockedConfirmation).when(httpClient).initiateConfirmationPayment( Mockito.any(), anyBoolean() );
 
         RedirectionPaymentRequest redirectionPaymentRequest = createCompleteRedirectionPaymentBuilder();
         mockCorrectlyConfigPropertiesEnum(true);
@@ -139,9 +143,13 @@ public class PaymentWithRedirectionServiceTest extends OneyConfigBean {
     }
 
     @Test
-    public void finalizeRedirectionPaymentNotEncryptedOK() throws HttpCallException {
-        StringResponse responseMocked = createStringResponse(200, "OK", "{\"purchase\":{\"status_code\":\"FUNDED\",\"status_label\":\"Transaction is completed\"}}");
-        Mockito.doReturn(responseMocked).when(httpClient).doPost(Mockito.anyString(), Mockito.anyString(), Mockito.anyMap());
+    public void finalizeRedirectionPaymentNotEncryptedOK() throws Exception {
+        StringResponse responseMocked = createStringResponse(200, "OK", "{\"purchase\":{\"status_code\":\"FAVORABLE\",\"status_label\":\"Transaction is completed\"}}");
+        StringResponse responseMockedConfirmation = createStringResponse(200, "OK", "{\"purchase\":{\"status_code\":\"FUNDED\",\"status_label\":\"Transaction is completed\"}}");
+
+        Mockito.doReturn(responseMocked).when(httpClient).initiateGetTransactionStatus( Mockito.any(), anyBoolean() );
+        Mockito.doReturn(responseMockedConfirmation).when(httpClient).initiateConfirmationPayment( Mockito.any(), anyBoolean() );
+
 
         RedirectionPaymentRequest redirectionPaymentRequest = createCompleteRedirectionPaymentBuilder();
         mockCorrectlyConfigPropertiesEnum(false);

--- a/src/test/java/com/payline/payment/oney/utils/OneyErrorHandlerTest.java
+++ b/src/test/java/com/payline/payment/oney/utils/OneyErrorHandlerTest.java
@@ -1,7 +1,7 @@
 package com.payline.payment.oney.utils;
 
 import com.payline.payment.oney.bean.response.OneyFailureResponse;
-import com.payline.payment.oney.exception.MalformedResponseException;
+import com.payline.payment.oney.exception.MalformedJsonException;
 import com.payline.payment.oney.utils.http.StringResponse;
 import com.payline.pmapi.bean.common.FailureCause;
 import com.payline.pmapi.bean.refund.response.impl.RefundResponseFailure;
@@ -103,7 +103,7 @@ public class OneyErrorHandlerTest {
     }
 
     @Test
-    public void handleOneyFailureResponseFromCause() throws MalformedResponseException {
+    public void handleOneyFailureResponseFromCause() throws MalformedJsonException {
         String json = "{\"Payments_Error_Response\":{\"error_list \":[{\"field\":\"payment.business_transaction.code\",\"error_code\":\"ERR_02\",\"error_label\":\"Size of the field should be less than or equal to [5] characters\"}]}}";
 
         StringResponse stringResponse = createStringResponse(400, "Bad request", json);

--- a/src/test/java/com/payline/payment/oney/utils/OneyErrorHandlerTest.java
+++ b/src/test/java/com/payline/payment/oney/utils/OneyErrorHandlerTest.java
@@ -17,7 +17,7 @@ public class OneyErrorHandlerTest {
 
     @Test
     public void testHandleOneyFailureResponse401() {
-        StringResponse stringResponse = createStringResponse(401, "Bad request", "{some content}");
+        StringResponse stringResponse = createStringResponse(401, "Unauthorized", "{some content}");
 
         OneyFailureResponse failureCause = OneyFailureResponse.fromJson(stringResponse.toString());
         FailureCause paylineFailureResponse = OneyErrorHandler.handleOneyFailureResponse(failureCause);
@@ -27,7 +27,7 @@ public class OneyErrorHandlerTest {
 
     @Test
     public void testHandleOneyFailureResponse403() {
-        StringResponse stringResponse = createStringResponse(403, "Bad request", "{some content}");
+        StringResponse stringResponse = createStringResponse(403, "Forbidden", "{some content}");
 
         OneyFailureResponse failureCause = OneyFailureResponse.fromJson(stringResponse.toString());
         FailureCause paylineFailureResponse = OneyErrorHandler.handleOneyFailureResponse(failureCause);
@@ -37,7 +37,7 @@ public class OneyErrorHandlerTest {
 
     @Test
     public void testHandleOneyFailureResponse500() {
-        StringResponse stringResponse = createStringResponse(500, "Bad request", "{some content}");
+        StringResponse stringResponse = createStringResponse(500, "Internal Server Error", "{some content}");
 
         OneyFailureResponse failureCause = OneyFailureResponse.fromJson(stringResponse.toString());
         FailureCause paylineFailureResponse = OneyErrorHandler.handleOneyFailureResponse(failureCause);
@@ -47,7 +47,7 @@ public class OneyErrorHandlerTest {
 
     @Test
     public void testHandleOneyFailureResponse404() {
-        StringResponse stringResponse = createStringResponse(404, "Bad request", "{some content}");
+        StringResponse stringResponse = createStringResponse(404, "Not Found", "{some content}");
 
         OneyFailureResponse failureCause = OneyFailureResponse.fromJson(stringResponse.toString());
         FailureCause paylineFailureResponse = OneyErrorHandler.handleOneyFailureResponse(failureCause);
@@ -57,7 +57,7 @@ public class OneyErrorHandlerTest {
 
     @Test
     public void testHandleOneyFailureResponse408() {
-        StringResponse stringResponse = createStringResponse(408, "Bad request", "{some content}");
+        StringResponse stringResponse = createStringResponse(408, "Request Time-out", "{some content}");
 
         OneyFailureResponse failureCause = OneyFailureResponse.fromJson(stringResponse.toString());
         FailureCause paylineFailureResponse = OneyErrorHandler.handleOneyFailureResponse(failureCause);
@@ -67,7 +67,7 @@ public class OneyErrorHandlerTest {
 
     @Test
     public void testHandleOneyFailureResponse429() {
-        StringResponse stringResponse = createStringResponse(429, "Bad request", "{some content}");
+        StringResponse stringResponse = createStringResponse(429, "Too Many Requests", "{some content}");
 
         OneyFailureResponse failureCause = OneyFailureResponse.fromJson(stringResponse.toString());
         FailureCause paylineFailureResponse = OneyErrorHandler.handleOneyFailureResponse(failureCause);
@@ -77,12 +77,20 @@ public class OneyErrorHandlerTest {
 
     @Test
     public void testHandleOneyFailureResponse503() {
-        StringResponse stringResponse = createStringResponse(503, "Bad request", "{some content}");
+        StringResponse stringResponse = createStringResponse(503, "Service Unavailable", "{some content}");
 
         OneyFailureResponse failureCause = OneyFailureResponse.fromJson(stringResponse.toString());
         FailureCause paylineFailureResponse = OneyErrorHandler.handleOneyFailureResponse(failureCause);
         Assertions.assertEquals(FailureCause.COMMUNICATION_ERROR, paylineFailureResponse);
+    }
 
+    @Test
+    public void testHandleOneyFailureResponse504() {
+        StringResponse stringResponse = createStringResponse(504, "Gateway Time-out", "{some content}");
+
+        OneyFailureResponse failureCause = OneyFailureResponse.fromJson(stringResponse.toString());
+        FailureCause paylineFailureResponse = OneyErrorHandler.handleOneyFailureResponse(failureCause);
+        Assertions.assertEquals(FailureCause.COMMUNICATION_ERROR, paylineFailureResponse);
     }
 
     @Test

--- a/src/test/java/com/payline/payment/oney/utils/PluginUtilsTest.java
+++ b/src/test/java/com/payline/payment/oney/utils/PluginUtilsTest.java
@@ -1,7 +1,6 @@
 package com.payline.payment.oney.utils;
 
 import com.payline.payment.oney.bean.common.purchase.Item;
-import com.payline.payment.oney.bean.common.purchase.Purchase;
 import com.payline.payment.oney.exception.InvalidDataException;
 import com.payline.payment.oney.exception.InvalidFieldFormatException;
 import com.payline.pmapi.bean.configuration.PartnerConfiguration;
@@ -22,10 +21,9 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static com.payline.payment.oney.bean.common.enums.CategoryCodeHandler.findCategory;
-import static com.payline.payment.oney.utils.BeanUtils.createDelivery;
-import static com.payline.payment.oney.utils.BeanUtils.createItemList;
 import static com.payline.payment.oney.utils.OneyConstants.*;
 import static com.payline.payment.oney.utils.PluginUtils.*;
+import static com.payline.payment.oney.utils.TestUtils.createDefaultPaymentRequest;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
@@ -457,5 +455,20 @@ public class PluginUtilsTest {
         Assertions.assertEquals("01234567890123456789", PluginUtils.truncate("01234567890123456789", 60));
         Assertions.assertEquals("", PluginUtils.truncate("", 30));
         Assertions.assertNull(PluginUtils.truncate(null, 30));
+    }
+
+    @Test
+    void createMerchantContext() {
+        String expectedMerchantContext = "CL!40800!EUR";
+        PaymentRequest request = createDefaultPaymentRequest();
+
+        //  creation test
+        String merchantContext = PluginUtils.createMerchantContext(request);
+        Assertions.assertEquals(expectedMerchantContext, merchantContext);
+
+        // recorery test
+        Assertions.assertEquals(false, PluginUtils.isCaptureNow(merchantContext));
+        Assertions.assertEquals(408.00, PluginUtils.getAmount(merchantContext));
+        Assertions.assertEquals("EUR", PluginUtils.getCurrency(merchantContext));
     }
 }

--- a/src/test/java/com/payline/payment/oney/utils/TestUtils.java
+++ b/src/test/java/com/payline/payment/oney/utils/TestUtils.java
@@ -2,6 +2,7 @@ package com.payline.payment.oney.utils;
 
 import com.payline.payment.oney.utils.http.StringResponse;
 import com.payline.payment.oney.utils.properties.service.ConfigPropertiesEnum;
+import com.payline.pmapi.bean.capture.request.CaptureRequest;
 import com.payline.pmapi.bean.common.Amount;
 import com.payline.pmapi.bean.common.Buyer;
 import com.payline.pmapi.bean.common.Buyer.Address;
@@ -48,7 +49,7 @@ public class TestUtils {
     private static final Currency CURRENCY_EUR = Currency.getInstance("EUR");
     private static final Locale LOCALE_FR = Locale.FRANCE;
 
-    private static final Environment TEST_ENVIRONMENT = new Environment(NOTIFICATION_URL, SUCCESS_URL, CANCEL_URL, true);
+    public static final Environment TEST_ENVIRONMENT = new Environment(NOTIFICATION_URL, SUCCESS_URL, CANCEL_URL, true);
 
     private static final String TEST_PSP_GUID_KEY = PSP_GUID_KEY + ".be";
     private static final String TEST_CHIFFREMENT_KEY = "\"66s581CG5W+RLEqZHAGQx+vskjy660Kt8x8rhtRpXtY=\"";
@@ -106,6 +107,19 @@ public class TestUtils {
                 .withSensitivePaymentFormParameter(sensitivePaymentFormParameter)
                 .build();
 
+    }
+
+    public static CaptureRequest createDefaultCaptureRequest(){
+        return  CaptureRequest.CaptureRequestBuilder.aCaptureRequest()
+                .withTransactionId(TRANSACTION_ID)
+                .withPartnerTransactionId(EXTERNAL_REFERENCE)
+                .withAmount(TestUtils.createAmount(Currency.getInstance("EUR")))
+                .withBuyer(TestUtils.createDefaultBuyer())
+                .withContractConfiguration(TestUtils.createContractConfiguration())
+                .withEnvironment(TestUtils.TEST_ENVIRONMENT)
+                .withOrder(TestUtils.createOrder(TRANSACTION_ID))
+                .withPartnerConfiguration(TestUtils.createDefaultPartnerConfiguration())
+                .build();
     }
 
 
@@ -191,6 +205,7 @@ public class TestUtils {
                 .withRequestData(requestData)
                 .build();
         return RedirectionPaymentRequest.builder()
+                .withCaptureNow(true)
                 .withAmount(amount)
                 .withBrowser(new Browser("", LOCALE_FR))
                 .withContractConfiguration(contractConfiguration)


### PR DESCRIPTION
PAYLAPMEXT-125 : correction du check

PAYLAPMEXT-150 :
* gestion des notification
* correction d'un test du `NotificationService`

PAYLAPMEXT-151 :
* gestion de l'autorisation simple (PAYLAPMEXT-151)
* ajout des tests du `CaptureService`
* correction des tests du `PaymentWithRedirectionService`
* confirme le paiement uniquement si le status est favorable
* correction du test chiffré de confirmation

PAYLAPMEXT-152 : validation différée
PAYLAPMEXT-154 : mapping de la fail URL
PAYLAPMEXT-164 : mapping du code erreur 504

PAYLAPMEXT-165 : 
* vérification du contenu de la requête de notification (erreur si non conforme à l'attendu)
* correction de l'inversion status_code/status_label
* ajout du status HTTP 204 dans l'objet `IgnoreNotificationResponse`

Correction des tests unitaires: erreur introduite par le rebase sur le résultat de la PR#23